### PR TITLE
norm file paths that are written to the vhdl ls toml file

### DIFF
--- a/src/vunit_helpers.py
+++ b/src/vunit_helpers.py
@@ -70,7 +70,7 @@ def generate_rust_hdl_toml(VU, output_file, file_root_path):
             if os.path.isabs(file.name):
                 files.append(str(file.name))
             else:
-                files.append(str(Path(file_root_path) / file.name))
+                files.append(str(os.path.normpath(Path(file_root_path) / file.name)))
 
         vhdl_ls["libraries"].update(
             {


### PR DESCRIPTION
Sometimes files were not recognized that they are part of the project, because the file path was not simplified.