### PR TITLE
support marking third party modules in vhdl_ls.toml

### DIFF
--- a/src/vunit_helpers.py
+++ b/src/vunit_helpers.py
@@ -46,7 +46,7 @@ def get_git_repo_root_path():
     return Path(git_repo_dir)
 
 
-def generate_rust_hdl_toml(VU, output_file, file_root_path):
+def generate_rust_hdl_toml(VU, output_file, file_root_path, third_party_libs=[]):
     """
     Generate the toml file required by rust_hdl (vhdl_ls).
 
@@ -75,7 +75,8 @@ def generate_rust_hdl_toml(VU, output_file, file_root_path):
         vhdl_ls["libraries"].update(
             {
                 lib.name: {
-                    "files": files
+                    "files": files,
+                    "is_third_party": lib.name in third_party_libs
                 }
             }
         )


### PR DESCRIPTION
To suppress warnings (e.g. unused declarations) of the VHDL language server, libraries can be marked as third-party.

This pull request adds the support of marking the third party libraries in the vhdl_ls.toml file. The third party libraries can be passed to the generate_rust_hdl_toml function.

With this new feature, the warnings reported by the language server are much more cleaner, since all the warnings from the third party modules can be suppressed.